### PR TITLE
Warnings from valgrind on 2bwm around return values of xcb_get_property()

### DIFF
--- a/2bwm.c
+++ b/2bwm.c
@@ -326,7 +326,7 @@ void check_name(struct client *client)
         if (NULL!=reply) free(reply);
         return;
     }
-    int reply_len = xcb_get_property_value_length(reply);
+    size_t reply_len = xcb_get_property_value_length(reply);
     char *wm_name_window = malloc(sizeof(char) * (reply_len + 1));
     memcpy(wm_name_window, xcb_get_property_value(reply), reply_len);
     wm_name_window[reply_len] = '\0';


### PR DESCRIPTION
This change set seeks to address the type (and perils) returned by xcb_get_property() and the need to use it alternatively as char, uint32_t or uint8_t as exposed by valgrind/memcheck.
