### PR TITLE
proper handling of _NET_SUPPORTING_WM_CHECK

### DIFF
--- a/2bwm.c
+++ b/2bwm.c
@@ -1907,10 +1907,15 @@ void ewmh_init(void)
 
 bool setup(int scrno)
 {
+    xcb_drawable_t cwin;
     screen = xcb_screen_of_display(conn, scrno);
     if (!screen) return false;
+    cwin = xcb_generate_id(conn);
+    xcb_create_window(conn, XCB_COPY_FROM_PARENT, cwin, screen->root, 0, 0, 10, 10, 0, XCB_WINDOW_CLASS_INPUT_OUTPUT, XCB_COPY_FROM_PARENT, 0, NULL);
     ewmh_init();
-    xcb_ewmh_set_wm_name(ewmh, screen->root, 4, "2bwm");
+    xcb_ewmh_set_wm_name(ewmh, cwin, 4, "2bwm");
+    xcb_ewmh_set_supporting_wm_check(ewmh, cwin, cwin);
+    xcb_ewmh_set_supporting_wm_check(ewmh, screen->root, cwin);
     xcb_atom_t net_atoms[] = {
         ewmh->_NET_SUPPORTED,             ewmh->_NET_WM_DESKTOP,
         ewmh->_NET_NUMBER_OF_DESKTOPS,    ewmh->_NET_CURRENT_DESKTOP,


### PR DESCRIPTION
- EWMH/NetWM requires setting _NET_SUPPORTING_WM_CHECK on the root
  to a check window owned by the window manager
- _NET_SUPPORTING_WM_CHECK and _NET_WM_NAME must be set also on
  the check window
