### PR TITLE
Add support for _NET_DESKTOP_NAMES

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 2bwm
 2bwm.o
 hidden
-**/tags

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 2bwm
 2bwm.o
 hidden
+**/tags

--- a/2bwm.c
+++ b/2bwm.c
@@ -3176,6 +3176,8 @@ setup(int scrno)
 	xcb_ewmh_set_number_of_desktops(ewmh, scrno, WORKSPACES);
 	xcb_ewmh_set_desktop_names(ewmh, scrno, ewmh_desktops_len, ewmh_desktops);
 
+	free(ewmh_desktops);
+
 	grabkeys();
 	/* set events */
 	for (i=0; i<XCB_NO_OPERATION; i++)
@@ -3192,7 +3194,6 @@ setup(int scrno)
 	events[XCB_BUTTON_PRESS]        = buttonpress;
 	events[XCB_CLIENT_MESSAGE]      = clientmessage;
 
-	free(ewmh_desktops);
 	return true;
 }
 

--- a/2bwm.c
+++ b/2bwm.c
@@ -3048,8 +3048,8 @@ bool
 setup(int scrno)
 {
 	unsigned int i, j;
-	unsigned int ewmh_desktops_len;
-	char* ewmh_desktops;
+	unsigned int ewmh_workspaces_len;
+	char* ewmh_workspaces;
 	uint32_t event_mask_pointer[] = { XCB_EVENT_MASK_POINTER_MOTION };
 
 	unsigned int values[1] = {
@@ -3155,28 +3155,28 @@ setup(int scrno)
 	if (error)
 		return false;
 
-	for(i = 0, ewmh_desktops_len = 0; desktops[i] != NULL; i++)
-		ewmh_desktops_len += strlen(desktops[i]) + 1;
+	for(i = 0, ewmh_workspaces_len = 0; workspaces[i] != NULL; i++)
+		ewmh_workspaces_len += strlen(workspaces[i]) + 1;
 
-	ewmh_desktops = malloc(sizeof(char) * ewmh_desktops_len);
+	ewmh_workspaces = malloc(sizeof(char) * ewmh_workspaces_len);
 
-	if(ewmh_desktops == NULL)
+	if(ewmh_workspaces == NULL)
 		return false;
 
-	/* build ewmh_desktops from desktops */
-	for(i=0; desktops[i] != NULL; i++)
+	/* build ewmh_workspaces from workspaces */
+	for(i=0; workspaces[i] != NULL; i++)
 	{
-		for(j=0; desktops[i][j] != '\0'; j++)
-			*ewmh_desktops++ = desktops[i][j];
-		*ewmh_desktops++ = '\0';
+		for(j=0; workspaces[i][j] != '\0'; j++)
+			*ewmh_workspaces++ = workspaces[i][j];
+		*ewmh_workspaces++ = '\0';
 	}
-	ewmh_desktops -= ewmh_desktops_len;
+	ewmh_workspaces -= ewmh_workspaces_len;
 
 	xcb_ewmh_set_current_desktop(ewmh, scrno, curws);
 	xcb_ewmh_set_number_of_desktops(ewmh, scrno, WORKSPACES);
-	xcb_ewmh_set_desktop_names(ewmh, scrno, ewmh_desktops_len, ewmh_desktops);
+	xcb_ewmh_set_desktop_names(ewmh, scrno, ewmh_workspaces_len, ewmh_workspaces);
 
-	free(ewmh_desktops);
+	free(ewmh_workspaces);
 
 	grabkeys();
 	/* set events */

--- a/config.h
+++ b/config.h
@@ -49,8 +49,8 @@ static void halfandcentered(const Arg *arg)
 	Arg arg3 = {.i=TWOBWM_TELEPORT_CENTER};
 	teleport(&arg3);
 }
-///---Desktop names---///
-static const char *desktops[] = {"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", NULL};
+///---Workspaces names---///
+static const char *workspaces[] = {"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", NULL};
 ///---Shortcuts---///
 /* Check /usr/include/X11/keysymdef.h for the list of all keys
  * 0x000000 is for no modkey

--- a/config.h
+++ b/config.h
@@ -49,6 +49,8 @@ static void halfandcentered(const Arg *arg)
 	Arg arg3 = {.i=TWOBWM_TELEPORT_CENTER};
 	teleport(&arg3);
 }
+///---Desktop names---///
+static const char *desktops[] = {"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", NULL};
 ///---Shortcuts---///
 /* Check /usr/include/X11/keysymdef.h for the list of all keys
  * 0x000000 is for no modkey
@@ -57,7 +59,7 @@ static void halfandcentered(const Arg *arg)
  * KeyRelease event, serial 40, synthetic NO, window 0x1e00001,
  *  root 0x98, subw 0x0, time 211120530, (128,73), root:(855,214),
  *  state 0x10, keycode 171 (keysym 0x1008ff17, XF86AudioNext), same_screen YES,
- *  XLookupString gives 0 bytes: 
+ *  XLookupString gives 0 bytes:
  *  XFilterEvent returns: False
  *
  *  The keycode here is keysym 0x1008ff17, so use  0x1008ff17


### PR DESCRIPTION
Some status bars (namely polybar) require _NET_DESKTOP_NAMES to be set in order to display the active workspace, else they crash. With this you can specify as many names as you want in config.h, and the rest of the workspaces will remain unnamed as they were before.