### PR TITLE
Optional outer border

### DIFF
--- a/2bwm.c
+++ b/2bwm.c
@@ -1901,15 +1901,26 @@ setborders(struct client *client,const bool isitfocused)
 	if (client->maxed || client->ignore_borders)
 		return;
 
+  bool has_tag = false;
+	if (client->unkillable || client->fixed)
+    has_tag = true;
+
 	/* Set border width. */
-	values[0] = conf.borderwidth;
+  if (has_tag || !(conf.no_outer_border)) {
+	  values[0] = conf.borderwidth;
+	  half = conf.outer_border;
+  } else {
+	  values[0] = conf.borderwidth - conf.outer_border;
+	  half = 0;
+  }
+
 	xcb_configure_window(conn, client->id,
 			XCB_CONFIG_WINDOW_BORDER_WIDTH, values);
 
 	if (top_win!=0 &&client->id ==top_win)
 		inv = !inv;
 
-	half = conf.outer_border;
+
 
 	xcb_rectangle_t rect_inner[] = {
 		{
@@ -2003,7 +2014,7 @@ setborders(struct client *client,const bool isitfocused)
 		else
 			if (client->fixed)
 				values[0]  = conf.fixedcol;
-			else
+      else
 				values[0]  = conf.unkillcol;
 	}
 
@@ -3097,6 +3108,7 @@ setup(int scrno)
 	conf.empty_col				= getcolor(colors[6]);
 	conf.inverted_colors	= inverted_colors;
 	conf.enable_compton	 = false;
+  conf.no_outer_border = false;
 
 	if (db != NULL)
 	{
@@ -3131,6 +3143,8 @@ setup(int scrno)
 
 		if (xcb_xrm_resource_get_string(db, "twobwm.enable_compton", NULL, &value) >= 0)
 			conf.enable_compton = strcmp(value, "true") == 0;
+    if (xcb_xrm_resource_get_string(db, "twobwm.no_outer_border", NULL, &value) >= 0)
+      conf.no_outer_border = strcmp(value, "true") == 0;
 	}
 
 	xcb_xrm_database_free(db);

--- a/types.h
+++ b/types.h
@@ -50,4 +50,5 @@ struct conf {
 	uint32_t focuscol,unfocuscol,fixedcol,unkillcol,empty_col,fixed_unkil_col,outer_border_col;
 	bool inverted_colors;
 	bool enable_compton;
+  bool no_outer_border;
 } conf;


### PR DESCRIPTION
This way the outer border is only drawn when a window is either unkillable or fixed.

Configurable with a new option in .Xresources