### PR TITLE
do not take in account offset when window ask to be maximized

### DIFF
--- a/2bwm.c
+++ b/2bwm.c
@@ -2861,13 +2861,13 @@ clientmessage(xcb_generic_event_t *ev)
 					unmaxwin(cl);
 					break;
 				case XCB_EWMH_WM_STATE_ADD:
-					maxwin(cl, true);
+					maxwin(cl, false);
 					break;
 				case XCB_EWMH_WM_STATE_TOGGLE:
 						if(cl->maxed)
 							unmaxwin(cl);
 						else
-							maxwin(cl, true);
+							maxwin(cl, false);
 					break;
 
 				default:


### PR DESCRIPTION
I just merged the change to my config and I made something that isn't quite a mistake but the fullscreen take in account the offset and I think it shouldn't