### PR TITLE
Memory leak fix

### DIFF
--- a/2bwm.c
+++ b/2bwm.c
@@ -33,7 +33,7 @@
 
 ///---Internal Constants---///
 ///---Globals---///
-static xcb_generic_event_t *ev = NULL;
+static xcb_generic_event_t *ev  = NULL;
 static void (*events[XCB_NO_OPERATION])(xcb_generic_event_t *e);
 static unsigned int numlockmask = 0;
 int sigcode = 0;                        // Signal code. Non-zero if we've been interruped by a signal.

--- a/config.h
+++ b/config.h
@@ -40,7 +40,7 @@ static const uint8_t borders[] = {3,5,5,4};
 #define LOOK_INTO "WM_NAME"
 static const char *ignore_names[] = {"bar", "xclock"};
 ///--Menus and Programs---///
-static const char *menucmd[]   = { "", NULL };
+static const char *menucmd[]   = { "/bin/st", NULL };
 ///--Custom foo---///
 static void halfandcentered(const Arg *arg)
 {

--- a/config.h
+++ b/config.h
@@ -40,7 +40,7 @@ static const uint8_t borders[] = {3,5,5,4};
 #define LOOK_INTO "WM_NAME"
 static const char *ignore_names[] = {"bar", "xclock"};
 ///--Menus and Programs---///
-static const char *menucmd[]   = { "/bin/st", NULL };
+static const char *menucmd[]   = { "", NULL };
 ///--Custom foo---///
 static void halfandcentered(const Arg *arg)
 {


### PR DESCRIPTION
1, Run 2bwm with valgrind using command:
valgrind --leak-check=full --show-leak-kinds=all 2bwm

2, Open up any X11 application e.g: inkscape, gimp etc.

3, After termination of 2bwm, valgrind shows the following:

LEAK SUMMARY:
   definitely lost: 36 bytes in 1 blocks
   indirectly lost: 0 bytes in 0 blocks
     possibly lost: 0 bytes in 0 blocks
   still reachable: 116 bytes in 4 blocks
        suppressed: 0 bytes in 0 blocks

4, One definite lost caused by calling xcb_ewmh_get_wm_window_type_reply() without free "win_type".  
solution: by moving xcb_ewmh_get_atoms_reply_wipe(&win_type) outside FOR loop solve the problem.

5, Still reachable memory leak can be solved by go throught winlist, monlist and wslist inside cleanup(). Maybe lite Pedantic but good programming practice.

6, Added few variable initiation.