### PR TITLE
fixwindow_without_cloning

### DIFF
--- a/2bwm.c
+++ b/2bwm.c
@@ -492,14 +492,14 @@ changeworkspace_helper(const uint32_t ws)
 		/* Go through list of current ws.
 		 * Unmap everything that isn't fixed. */
 		client = item->data;
-        item = item->next;
+		item = item->next;
 		setborders(client,false);
 		if (!client->fixed)
 			xcb_unmap_window(conn, client->id);
-        else{
-            addtoworkspace(client,ws);
-            delfromworkspace(client,curws);
-        }
+		else{
+			addtoworkspace(client,ws);
+			delfromworkspace(client,curws);
+		}
 	}
 
 	for (item=wslist[ws]; item != NULL; item = item->next) {
@@ -557,10 +557,6 @@ fixwindow(struct client *client)
 				ewmh->_NET_WM_DESKTOP, XCB_ATOM_CARDINAL, 32, 1,
 				&curws
 		);
-
-		/* Delete from all workspace lists except current. */
-//		for (ws=0; ws < WORKSPACES; ws ++)
-//			if (ws != curws) delfromworkspace(client, ws);
 	} else {
 		/* Raise the window, if going to another desktop don't
 		 * let the fixed window behind. */
@@ -571,10 +567,6 @@ fixwindow(struct client *client)
 				ewmh->_NET_WM_DESKTOP, XCB_ATOM_CARDINAL, 32, 1,
 				&ww
 		);
-
-		/* Add window to all workspace lists. */
-//		for (ws=0; ws < WORKSPACES; ws ++)
-//			if (ws != curws) addtoworkspace(client, ws);
 	}
 
 	setborders(client,true);

--- a/2bwm.c
+++ b/2bwm.c
@@ -488,13 +488,18 @@ changeworkspace_helper(const uint32_t ws)
 		return;
 
 	xcb_ewmh_set_current_desktop(ewmh, 0, ws);
-	for (item=wslist[curws]; item != NULL; item = item->next) {
+	for (item=wslist[curws]; item != NULL;) {
 		/* Go through list of current ws.
 		 * Unmap everything that isn't fixed. */
 		client = item->data;
+        item = item->next;
 		setborders(client,false);
 		if (!client->fixed)
 			xcb_unmap_window(conn, client->id);
+        else{
+            addtoworkspace(client,ws);
+            delfromworkspace(client,curws);
+        }
 	}
 
 	for (item=wslist[ws]; item != NULL; item = item->next) {
@@ -554,8 +559,8 @@ fixwindow(struct client *client)
 		);
 
 		/* Delete from all workspace lists except current. */
-		for (ws=0; ws < WORKSPACES; ws ++)
-			if (ws != curws) delfromworkspace(client, ws);
+//		for (ws=0; ws < WORKSPACES; ws ++)
+//			if (ws != curws) delfromworkspace(client, ws);
 	} else {
 		/* Raise the window, if going to another desktop don't
 		 * let the fixed window behind. */
@@ -568,8 +573,8 @@ fixwindow(struct client *client)
 		);
 
 		/* Add window to all workspace lists. */
-		for (ws=0; ws < WORKSPACES; ws ++)
-			if (ws != curws) addtoworkspace(client, ws);
+//		for (ws=0; ws < WORKSPACES; ws ++)
+//			if (ws != curws) addtoworkspace(client, ws);
 	}
 
 	setborders(client,true);


### PR DESCRIPTION
1, fixwindow(client) add/remove the client window to/from all workspaces except the current one. If I understand correct, only one workspace is visible to user from a certain monitor in a certain time. 

2, If the previous statement is corrent, The fixwindow(client) can be as easy as setting client->fix to true/false. and changeworkspace_helper(ws)  needs send the fixed client to the desired worksapce.

3, I made as few changes as possible to archive the same result as the original code. In case this pull is accepted, more clean up maybe needed. E.g: if xcb_change_property still required in fixwindow(client)?