### PR TITLE
Change wsitem

### DIFF
--- a/config.h
+++ b/config.h
@@ -160,7 +160,7 @@ static key keys[] = {
     {  MOD |SHIFT ,       XK_v,          sendtonextworkspace,{}},
     {  MOD |SHIFT ,       XK_c,          sendtoprevworkspace,{}},
     // Iconify the window
-    //{  MOD ,              XK_i,          hide,              {}},
+    {  MOD ,              XK_i,          hide,              {}},
     // Make the window unkillable
     {  MOD ,              XK_a,          unkillable,        {}},
     // Make the window appear always on top

--- a/types.h
+++ b/types.h
@@ -7,7 +7,7 @@ struct monitor {
 };
 typedef union {
 	const char** com;
-	const int8_t i;
+	const uint32_t i;
 } Arg;
 typedef struct {
 	unsigned int mod;
@@ -36,7 +36,8 @@ struct client {                     // Everything we know about a window.
 	bool fixed,unkillable,vertmaxed,hormaxed,maxed,verthor,ignore_borders,iconic;
 	struct monitor *monitor;        // The physical output this window is on.
 	struct item *winitem;           // Pointer to our place in global windows list.
-	struct item *wsitem[WORKSPACES];// Pointer to our place in every workspace window list.
+	struct item *wsitem;            // Pointer to workspace window list.
+	int ws;                         // In which workspace this window belongs to.
 };
 struct winconf {                    // Window configuration data.
 	int16_t      x, y;


### PR DESCRIPTION
Here comes motivations/suggestions for this pull:

1, I have chosen to keep the name wsitem instead wspointer because client->wsitem->next feels more consistent with item->next.

2, Using client->ws = -1 as initial value. Because "0" makes the client belongs to a certain workspace that is not the purpose.

3, Function delfromworkspace(client) no longer takes workspace as an argument, due to client->ws and client->wsitem are paired together and shouldn't be changed separately by misstake.

4, Function focusnext() has been changed with both readability and efficiency in mind. The idea is to make the workspace list temporary circular and easy to traversal. The ideal solution would be having a circular workspace list all the time but that require changes beyond this pull.

5, Function getpointer() check pointer variable after free(pointer), which I think is not the intention.
