### PR TITLE
transient_crashes_windows

### DIFF
--- a/2bwm.c
+++ b/2bwm.c
@@ -1002,7 +1002,8 @@ setupwin(xcb_window_t win)
 		client->base_width  = hints.base_width;
 		client->base_height = hints.base_height;
 	}
-
+	// this function crashs any X11 application e.g: inkscape, firefox.
+	// sub windows started from terminal.
 	cookie = xcb_icccm_get_wm_transient_for_unchecked(conn, win);
 	xcb_generic_error_t *error;
 	result = xcb_icccm_get_wm_transient_for_reply(conn, cookie, prop, &error);

--- a/config.h
+++ b/config.h
@@ -40,7 +40,7 @@ static const uint8_t borders[] = {3,5,5,4};
 #define LOOK_INTO "WM_NAME"
 static const char *ignore_names[] = {"bar", "xclock"};
 ///--Menus and Programs---///
-static const char *menucmd[]   = { "", NULL };
+static const char *menucmd[]   = { "/bin/urxvt", NULL };
 ///--Custom foo---///
 static void halfandcentered(const Arg *arg)
 {


### PR DESCRIPTION
1, Start X11 application e.g: inkscape from terminal/urxvt/st, then File->Open. inkscape crashes as well as 2bwm.
2, Valgrind output:
Invalid write of size 4
xcb_icccm_get_wm_transient_for_from_reply