### PR TITLE
Fix crash caused by hardcoded TWOBWM_PATH

### DIFF
--- a/2bwm.c
+++ b/2bwm.c
@@ -33,6 +33,7 @@
 
 ///---Internal Constants---///
 ///---Globals---///
+static const char * program_name;
 static xcb_generic_event_t *ev  = NULL;
 static void (*events[XCB_NO_OPERATION])(xcb_generic_event_t *e);
 static unsigned int numlockmask = 0;
@@ -3330,7 +3331,7 @@ twobwm_restart(void)
 		free(ewmh);
 
 	xcb_disconnect(conn);
-	execvp(TWOBWM_PATH, NULL);
+	execlp(program_name, program_name, NULL);
 }
 
 void
@@ -3362,6 +3363,7 @@ install_sig_handlers(void)
 int
 main(int argc, char **argv)
 {
+	program_name = argv[0];
 	int scrno = 0;
 	atexit(cleanup);
 	install_sig_handlers();

--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,13 @@ RM=/bin/rm
 PREFIX?=/usr/local
 LIB_SUFFIX?=lib
 MANPREFIX?=$(PREFIX)/share/man
-TWOBWM_PATH?=${PREFIX}/bin/2bwm
 X11_INCLUDE?=/usr/local/include
 
 #CC=clang
 DIST=2bwm-$(VERSION)
 SRC=2bwm.c list.h hidden.c config.h
 DISTFILES=Makefile README.md TODO 2bwm.man $(SRC)
-CFLAGS+=-Os -s -I${X11_INCLUDE} \
-		-DTWOBWM_PATH=\"${TWOBWM_PATH}\" 
+CFLAGS+=-Os -s -I${X11_INCLUDE}
 
 LDFLAGS+=-L${PREFIX}/${LIB_SUFFIX} -lxcb -lxcb-randr -lxcb-keysyms \
 		 -lxcb-icccm -lxcb-ewmh -lxcb-xrm


### PR DESCRIPTION
This fixes a potential crash due to hardcoding TWOBWM_PATH in the Makefile. If a user does not install the 2bwm binary to the hardcoded path, as can happen with certain package managers, 2bwm will crash when calling twobwm_restart. Instead, a global variable is set to argv[0] which contains the program name and the 'p' flavor of exec syscalls will find 2bwm in the user's $PATH. This commit also fixes a warning triggered by -Wnonnull where execvp was receiving NULL instead of its expected vector argument. The call was changed to execlp and supplied the expected arguments.