### PR TITLE
Fix documentation: link broken, installation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Available on the AUR:
 
 Download and extract the tarball, then install it as a package:
 
-    $ git clone https://aur.archlinux.org/packages/2bwm.git
+    $ git clone https://aur.archlinux.org/2bwm.git
     $ cd 2bwm
     $ makepkg
     # pacman -U 2bwm-*.pkg.tar.xz

--- a/README.md
+++ b/README.md
@@ -164,11 +164,11 @@ Available on the AUR:
 
 Download and extract the tarball, then install it as a package:
 
-    $ curl -s 'https://aur.archlinux.org/packages/2b/2bwm/2bwm.tar.gz'|tar xzf -
+    $ git clone https://aur.archlinux.org/packages/2bwm.git
     $ cd 2bwm
-    $ ${EDITOR:=vi} config.h
     $ makepkg
     # pacman -U 2bwm-*.pkg.tar.xz
+    $ cd src/2bwm/ && vim config.h
 
 CRUX
 ----


### PR DESCRIPTION
```
$ curl -s 'https://aur.archlinux.org/packages/2b/2bwm/2bwm.tar.gz' | tar xzf -

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
```

The link appears to be broken; I have also manually verified it on [aur](https://aur.archlinux.org/). It might be easier to install and configure in the following way.

You may want to consider merging this pull request.

